### PR TITLE
chore: Update .gitignore to replace package-lock.json with pnpm-lock.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 
 # dependencies
 /node_modules
-package-lock.json
+pnpm-lock.yaml
 
 # testing
 /coverage


### PR DESCRIPTION
- Remove package-lock.json to align with the use of pnpm as the package manager.