### PR TITLE
feat: Integrate Vercel Speed Insights for Performance Monitoring

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { Geist } from "next/font/google";
 import { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
 import { Analytics } from "@vercel/analytics/next"
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import NavBar from "@/components/navbar";
 import "./globals.css";
 
@@ -65,6 +66,7 @@ export default function RootLayout({
               <div className="flex flex-col gap-20 max-w-5xl p-5">
                 {children}
                 <Analytics />
+                <SpeedInsights />
               </div>
             </div>
           </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,14 +25,16 @@ export const metadata: Metadata = {
   metadataBase: new URL(defaultUrl),
   title: meta.title,
   description: meta.description,
-  applicationName: "The Reyes Vault",
+  applicationName: meta.siteName,
   openGraph: {
     type: 'website',
     title: meta.title,
     siteName: meta.siteName,
     description: meta.description,
+    url: defaultUrl,
   },
   twitter: {
+    card: 'summary_large_image',
     title: meta.title,
     description: meta.description,
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "@vercel/analytics": "^1.5.0",
+    "@vercel/speed-insights": "^1.2.0",
     "autoprefixer": "10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
This PR integrates Vercel Speed Insights to enhance our application's performance monitoring capabilities alongside the existing Analytics implementation. Speed Insights will help us track and analyze real user performance metrics.

Changes:
- Add @vercel/speed-insights dependency
- Integrate SpeedInsights component in root layout
- Place SpeedInsights alongside Analytics for comprehensive monitoring

Benefits:
- Real-time performance monitoring
- Core Web Vitals tracking
- User experience metrics
- Automatic performance data collection

Dependencies:
- @vercel/speed-insights: ^1.2.0