### PR TITLE
chore: Remove unused imports and uuid dependency

### DIFF
--- a/app/(user)/dashboard/page.tsx
+++ b/app/(user)/dashboard/page.tsx
@@ -1,6 +1,5 @@
 import { createClient } from "@/utils/supabase/server"
 import { InfoIcon } from "lucide-react";
-import { redirect } from "next/navigation";
 
 export default async function Page() {
   const supabase = await createClient();

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -2,8 +2,6 @@
 
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
-import { validateTurnstileToken } from 'next-turnstile';
-import { v4 as uuidv4 } from 'uuid';
 import { encodedRedirect } from "@/utils/utils";
 import { createClient } from "@/utils/supabase/server";
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "prettier": "^3.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwind-merge": "^3.3.0",
-    "uuid": "^11.1.0"
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
@@ -34,7 +33,6 @@
     "@types/node": "^20.17.47",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.5",
-    "@types/uuid": "^10.0.0",
     "eslint": "^9.27.0",
     "eslint-config-next": "15.3.2",
     "postcss": "8.4.49",


### PR DESCRIPTION
- Remove unused `redirect` import from dashboard page
- Remove unused `turnstile` and `uuid` imports from actions
- Remove `uuid` package and `@types/uuid` from dependencies