### PR TITLE
fix: Prevent mobile auto-zoom on login inputs and update styles

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -93,15 +93,15 @@ export function LoginForm({
     <div className={cn('flex flex-col', className)} {...props}>
       <Card className='bg-background border-none shadow-none'>
         <CardHeader>
-          <CardTitle className='text-xl text-center'>Welcome to The Reyes Vault</CardTitle>
+          <CardTitle className='text-2xl text-center'>Welcome to The Reyes Vault</CardTitle>
           {isDemoMode && isDemoModeEnabled ? (
-            <CardDescription className='text-center text-sm'>
+            <CardDescription className='text-center text-base'>
               Complete the security check and click the anonymous log in button to enter
             </CardDescription>
           ) : isDemoMode && !isDemoModeEnabled ? (
             null
           ) : (
-            <CardDescription className='text-center text-sm'>
+            <CardDescription className='text-center text-base'>
               Enter your email below to login to your account
             </CardDescription>
           )}
@@ -171,12 +171,11 @@ export function LoginForm({
             <CardContent>
               <div className='flex flex-col gap-6'>
                 <div className='grid gap-2'>
-                  <Label htmlFor='email'>Email</Label>
+                  <Label htmlFor='email' className='text-base'>Email</Label>
                   <Input
                     id='email'
                     type='email'
                     name='email'
-                    placeholder='you@example.com'
                     required
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
@@ -184,10 +183,10 @@ export function LoginForm({
                 </div>
                 <div className='grid gap-2'>
                   <div className='flex items-center'>
-                    <Label htmlFor='password'>Password</Label>
+                    <Label htmlFor='password' className='text-base'>Password</Label>
                     <Link
                       href='/forgot-password'
-                      className='ml-auto inline-block text-sm underline-offset-4 hover:underline'
+                      className='ml-auto inline-block text-base underline-offset-4 hover:underline'
                     >
                       Forgot your password?
                     </Link>
@@ -196,7 +195,6 @@ export function LoginForm({
                     id='password'
                     type='password'
                     name='password'
-                    placeholder='Your password'
                     required
                   />
                 </div>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}


### PR DESCRIPTION
# **Description**

This PR addresses an issue where mobile browsers, particularly on iOS, would automatically zoom in when focusing on input fields in the login form. This was caused by the input fields having a font size smaller than 16px.

### **Key Changes:**

*   **`components/ui/input.tsx`**:
    *   Increased the default font size of the `Input` component from `text-sm` to `text-base` (16px). This change globally prevents the auto-zoom behavior for all instances of this input component.
*   **`components/login-form.tsx`**:
    *   Updated `CardTitle` from `text-xl` to `text-2xl` for better visual hierarchy.
    *   Updated `CardDescription`, `Label` components, and the "Forgot your password?" link to use `text-base` for consistency with the updated input field font size.
    *   Removed the `placeholder` attributes from the email and password input fields as they are no longer necessary with the labels and general form structure.

### **Impact:**

*   Improves the user experience on mobile devices by eliminating the annoying auto-zoom on input focus.
*   Ensures the page view remains consistent after login or when errors are displayed.
*   Maintains a consistent visual style across the login form components.