### PR TITLE
feat(SEO): Add page metadata and improve title handling

### DIFF
--- a/app/(auth-pages)/forgot-password/page.tsx
+++ b/app/(auth-pages)/forgot-password/page.tsx
@@ -4,6 +4,12 @@ import { SubmitButton } from "@/components/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import Link from "next/link";
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Forgot Password',
+  description: 'Forgot your password? Enter your email address and we will send you a password reset link.'
+}
 
 export default async function ForgotPassword(props: {
   searchParams: Promise<Message>;

--- a/app/(auth-pages)/login/page.tsx
+++ b/app/(auth-pages)/login/page.tsx
@@ -1,4 +1,10 @@
 import { LoginForm } from "@/components/login-form/form";
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Login',
+  description: 'Log in to your account to access your memories from The Reyes Vault.'
+}
 
 export default function Login() {
   return (

--- a/app/(auth-pages)/reset-password/page.tsx
+++ b/app/(auth-pages)/reset-password/page.tsx
@@ -3,6 +3,11 @@ import { FormMessage, Message } from "@/components/form-message";
 import { SubmitButton } from "@/components/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Reset Password'
+}
 
 export default async function ResetPassword(props: {
   searchParams: Promise<Message>;

--- a/app/(authenticated)/(albums)/albums/page.tsx
+++ b/app/(authenticated)/(albums)/albums/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Albums'
+}
+
 export default async function Page() {
   return (
     <h1>Albums page</h1>

--- a/app/(authenticated)/(albums)/upload/page.tsx
+++ b/app/(authenticated)/(albums)/upload/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Upload'
+}
+
 export default async function Page() {
   return (
     <h1>Upload page</h1>

--- a/app/(authenticated)/(user)/dashboard/page.tsx
+++ b/app/(authenticated)/(user)/dashboard/page.tsx
@@ -1,8 +1,13 @@
-import { createClient } from "@/utils/supabase/server"
+import { createServerClient } from "@/utils/supabase/server"
 import { InfoIcon } from "lucide-react";
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Dashboard'
+}
 
 export default async function Page() {
-  const supabase = await createClient();
+  const supabase = await createServerClient();
 
   const {
     data: { user },

--- a/app/(authenticated)/(user)/profile/page.tsx
+++ b/app/(authenticated)/(user)/profile/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Profile'
+}
+
 export default async function Page() {
   return (
     <h1>Profile page</h1>

--- a/app/(authenticated)/memories/audio/page.tsx
+++ b/app/(authenticated)/memories/audio/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Audio'
+}
+
 export default async function Page() {
   return (
     <h1>Audio page</h1>

--- a/app/(authenticated)/memories/music/page.tsx
+++ b/app/(authenticated)/memories/music/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Music'
+}
+
 export default async function Page() {
   return (
     <h1>Music page</h1>

--- a/app/(authenticated)/memories/page.tsx
+++ b/app/(authenticated)/memories/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Memories'
+}
+
 export default async function Page() {
   return (
     <h1>All memories page</h1>

--- a/app/(authenticated)/memories/photos/page.tsx
+++ b/app/(authenticated)/memories/photos/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Photos'
+}
+
 export default async function Page() {
   return (
     <h1>Photos page</h1>

--- a/app/(authenticated)/memories/vhs/page.tsx
+++ b/app/(authenticated)/memories/vhs/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'VHS Tapes'
+}
+
 export default async function Page() {
   return (
     <h1>VHS page</h1>

--- a/app/(authenticated)/memories/videos/page.tsx
+++ b/app/(authenticated)/memories/videos/page.tsx
@@ -1,3 +1,9 @@
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Videos'
+}
+
 export default async function Page() {
   return (
     <h1>Videos page</h1>

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,7 +3,7 @@
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { encodedRedirect } from "@/utils/utils";
-import { createClient } from "@/utils/supabase/server";
+import { createServerClient } from "@/utils/supabase/server";
 
 export interface ActionErrorState {
   error?: string;
@@ -15,7 +15,7 @@ export const logInAction = async (
 ) => {
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
-  const supabase = await createClient();
+  const supabase = await createServerClient();
 
   const { error } = await supabase.auth.signInWithPassword({
     email,
@@ -46,7 +46,7 @@ export const anonymousLogInAction = async (
     return { error: 'CAPTCHA response missing. Please try again.' };
   }
 
-  const supabase = await createClient();
+  const supabase = await createServerClient();
   const { error } = await supabase.auth.signInAnonymously({
     options: { captchaToken }
   });
@@ -60,7 +60,7 @@ export const anonymousLogInAction = async (
 }
 
 export const logOutAction = async () => {
-  const supabase = await createClient();
+  const supabase = await createServerClient();
   const { error } = await supabase.auth.signOut();
 
   if (error) {
@@ -73,7 +73,7 @@ export const logOutAction = async () => {
 
 export const forgotPasswordAction = async (formData: FormData) => {
   const email = formData.get("email")?.toString();
-  const supabase = await createClient();
+  const supabase = await createServerClient();
   const origin = (await headers()).get("origin");
   const callbackUrl = formData.get("callbackUrl")?.toString();
 
@@ -106,7 +106,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
 };
 
 export const resetPasswordAction = async (formData: FormData) => {
-  const supabase = await createClient();
+  const supabase = await createServerClient();
 
   const password = formData.get("password") as string;
   const confirmPassword = formData.get("confirmPassword") as string;

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@/utils/supabase/server";
+import { createServerClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
@@ -11,7 +11,7 @@ export async function GET(request: Request) {
   const redirectTo = requestUrl.searchParams.get("redirect_to")?.toString();
 
   if (code) {
-    const supabase = await createClient();
+    const supabase = await createServerClient();
     await supabase.auth.exchangeCodeForSession(code);
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,27 +17,36 @@ interface Meta {
 
 const meta: Meta = {
   title: 'The Reyes Vault',
-  description: "Digital vault for preserving family memories. Forever, searchable, and safe in the cloud.",
+  description: "A digital vault for preserving family memories. Forever, searchable, and safe in the cloud.",
   siteName: 'The Reyes Vault',
   creator: 'James Reyes'
 }
 
 export const metadata: Metadata = {
   metadataBase: new URL(defaultUrl),
-  title: meta.title,
+  title: {
+    template: `%s | ${meta.title}`,
+    default: meta.title
+  },
   description: meta.description,
   applicationName: meta.siteName,
   creator: meta.creator,
   openGraph: {
     type: 'website',
-    title: meta.title,
+    title: {
+      template: `%s | ${meta.title}`,
+      default: meta.title
+    },
     siteName: meta.siteName,
     description: meta.description,
     url: defaultUrl,
   },
   twitter: {
     card: 'summary_large_image',
-    title: meta.title,
+    title: {
+      template: `%s | ${meta.title}`,
+      default: meta.title
+    },
     description: meta.description,
   },
   appleWebApp: {


### PR DESCRIPTION
- Add Next.js metadata to all page components for better SEO
- Configure title template to include site name (pageName | The Reyes Vault)
- Add descriptive metadata for auth pages (login, forgot password)
- Fix createClient usage across application by replacing with renamed createServerClient
- Enhance root layout metadata with templated titles and improved descriptions