### PR TITLE
fix(sidebar): Update tooltip trigger and visibility logic

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -540,9 +540,9 @@ function SidebarMenuButton({
       side="right"
       align="center"
     >
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipTrigger>{button}</TooltipTrigger>
       <TooltipContent
-        hidden={state !== "collapsed" || isMobile}
+        // hidden={state !== "collapsed" || isMobile}
         {...tooltip}
       />
     </Tooltip>


### PR DESCRIPTION
- Fixed new TooltipTrigger to not use `asChild` prop.
- Commented out the `hidden` prop in TooltipContent to allow for future adjustments in visibility logic.