### PR TITLE
fix: Correct typos in Supabase client utility functions

### DIFF
--- a/src/utils/supabase/admin.ts
+++ b/src/utils/supabase/admin.ts
@@ -8,7 +8,7 @@ import { urlConfig, supabaseConfig } from '@/lib/config';
  *
  * @returns A Supabase admin client instance.
  */
-export async function createAdminClint() {
+export async function createAdminClient() {
   return createClient(
     urlConfig.supabase,
     supabaseConfig.serviceRoleKey,

--- a/src/utils/supabase/client.ts
+++ b/src/utils/supabase/client.ts
@@ -6,7 +6,7 @@ import { urlConfig, supabaseConfig } from '@/lib/config';
  * @returns A Supabase browser client instance.
  */
 export function createBrowserClient() {
-  supaBrowserClient(
+  return supaBrowserClient(
     urlConfig.supabase,
     supabaseConfig.anonKey,
   );


### PR DESCRIPTION
- Fixed the typo in the function name from `createAdminClint` to `createAdminClient` in `admin.ts`.
- Added a missing `return` statement in the `createBrowserClient` function in `client.ts`.

These changes enhance code clarity and ensure proper functionality of the Supabase client utilities.