### PR TITLE
fix: Remove conflicting optimization configs and adjust PWA status bar

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -21,8 +21,6 @@ const nextConfig: NextConfig = {
       '@radix-ui/react-slot'
     ],
   },
-  // Minimize JavaScript
-  swcMinify: true,
   // Optimize images
   images: {
     formats: ['image/webp', 'image/avif'],
@@ -32,12 +30,6 @@ const nextConfig: NextConfig = {
   compress: true,
   // Modern JavaScript target
   transpilePackages: [],
-  // Additional optimizations
-  modularizeImports: {
-    'lucide-react': {
-      transform: 'lucide-react/dist/esm/icons/{{member}}',
-    },
-  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "the-reyes-vault",
   "private": true,
   "license": "MIT",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "the-reyes-vault",
   "private": true,
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,7 +53,7 @@ export const metadata: Metadata = {
   appleWebApp: {
     capable: true,
     title: meta.title,
-    statusBarStyle: 'black-translucent',
+    statusBarStyle: 'default',
     startupImage: '/apple-touch-icon.png'
   },
   icons: {


### PR DESCRIPTION
- Remove `modularizeImports` for lucide-react (conflicts with `optimizePackageImports`)
- Remove redundant swcMinify flag
- Change PWA `statusBarStyle` from 'black-translucent' to 'default' for better compatibility